### PR TITLE
11.1.0 toc update

### DIFF
--- a/CrossHotbar.toc
+++ b/CrossHotbar.toc
@@ -1,4 +1,4 @@
-## Interface: 110005
+## Interface: 110100
 
 ## Title: CrossHotbar
 ## Version: 1.0.9


### PR DESCRIPTION
This update addresses a compatibility issue where the addon does not load correctly with the current version of the game due to an incompatibility with the LibActionButton-1.0 version.

The issue occurs because the current version of the library does not properly support the latest game API, specifically related to the use of FlyoutButtonMixin. Additionally, when downloading the addon via CurseForge, the packaging process ends up pulling an outdated version of LibActionButton-1.0.

I have tested these changes, and the addon now works correctly with the current version of WoW.